### PR TITLE
Remove performNoDeepMerging to authorise theme folder addition

### DIFF
--- a/src/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
+++ b/src/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
@@ -45,7 +45,6 @@ final class FilesystemConfigurationSourceFactory implements ConfigurationSourceF
             ->arrayNode('directories')
                 ->defaultValue(['%kernel.project_dir%/themes'])
                 ->requiresAtLeastOneElement()
-                ->performNoDeepMerging()
                 ->prototype('scalar')
         ;
     }


### PR DESCRIPTION
The `performNoDeepMerging` do not allow to add more theme folders in config file or using compiler pass so I removed it. 